### PR TITLE
PostgreSQL::OID::Money.precision doesn't exists anymore with rails > 5

### DIFF
--- a/lib/active_record/connection_adapters/em_postgresql_adapter.rb
+++ b/lib/active_record/connection_adapters/em_postgresql_adapter.rb
@@ -162,7 +162,7 @@ module ActiveRecord
       # should know about this but can't detect it there, so deal with it here.
       if ActiveRecord.version < Gem::Version.new('4.2.0')
         ActiveRecord::ConnectionAdapters::PostgreSQLColumn.money_precision = (client.server_version >= 80300) ? 19 : 10
-      else
+      elsif ActiveRecord.version < Gem::Version.new('5.0.0')
         ActiveRecord::ConnectionAdapters::EMPostgreSQLAdapter::OID::Money.precision = (client.server_version >= 80300) ? 19 : 10
         # ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Money.precision = (client.server_version >= 80300) ? 19 : 10
       end


### PR DESCRIPTION
Tested with rails5 and rails6